### PR TITLE
Ajout champ "site_name"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
 ## Version 0.2.0
 
-- Ajout du champ `site_name` (champ obligatoire)
+- Ajout du champ `site_name` (champ obligatoire), voir [#22](https://github.com/etalab/schema-comptage-mobilites-site/issues/22)
 
 ## Version 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
-## Version 0.1
+## Version 0.2.0
+
+- Ajout du champ "name" (champ obligatoire)
+
+## Version 0.1.0
 
 - Première version publiée du schéma
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
 ## Version 0.2.0
 
-- Ajout du champ "name" (champ obligatoire)
+- Ajout du champ `site_name` (champ obligatoire)
 
 ## Version 0.1.0
 

--- a/exemple-valide-eco-compteur.csv
+++ b/exemple-valide-eco-compteur.csv
@@ -1,3 +1,3 @@
-site_id,parent_site_id,name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
+site_id,parent_site_id,site_name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
 300017533,,ecocounter-site,,-1.52594089508057,47.2190434510902,,
 300014141,,ecocounter-site,,-1.26849856736067,47.3389188762202,EV6,GREENWAY

--- a/exemple-valide-eco-compteur.csv
+++ b/exemple-valide-eco-compteur.csv
@@ -1,3 +1,3 @@
-site_id,parent_site_id,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
-300017533,,,-1.52594089508057,47.2190434510902,,
-300014141,,,-1.26849856736067,47.3389188762202,EV6,GREENWAY
+site_id,parent_site_id,name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
+300017533,,ecocounter-site,-1.52594089508057,47.2190434510902,,
+300014141,,ecocounter-site,-1.26849856736067,47.3389188762202,EV6,GREENWAY

--- a/exemple-valide-eco-compteur.csv
+++ b/exemple-valide-eco-compteur.csv
@@ -1,3 +1,3 @@
 site_id,parent_site_id,name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
-300017533,,ecocounter-site,-1.52594089508057,47.2190434510902,,
-300014141,,ecocounter-site,-1.26849856736067,47.3389188762202,EV6,GREENWAY
+300017533,,ecocounter-site,,-1.52594089508057,47.2190434510902,,
+300014141,,ecocounter-site,,-1.26849856736067,47.3389188762202,EV6,GREENWAY

--- a/exemple-valide.csv
+++ b/exemple-valide.csv
@@ -1,2 +1,2 @@
-site_id,parent_site_id,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
-C01-Baix,C-Baix,72010,1.452323,46.59698,07022-AC-001,GREENWAY
+site_id,parent_site_id,name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
+C01-Baix,C-Baix,Baix,72010,1.452323,46.59698,07022-AC-001,GREENWAY

--- a/exemple-valide.csv
+++ b/exemple-valide.csv
@@ -1,2 +1,2 @@
-site_id,parent_site_id,name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
+site_id,parent_site_id,site_name,fr_insee_code,xlong,ylat,external_ids,infrastructure_type
 C01-Baix,C-Baix,Baix,72010,1.452323,46.59698,07022-AC-001,GREENWAY

--- a/schema.json
+++ b/schema.json
@@ -20,17 +20,17 @@
       {
          "title": "Fichier valide (CSV)",
          "name": "exemple-valide-csv",
-         "path": "https://raw.githubusercontent.com/etalab/comptage-mobilites-site/v0.1.0/exemple-valide.csv"
+         "path": "https://raw.githubusercontent.com/etalab/comptage-mobilites-site/v0.2.0/exemple-valide.csv"
       },
       {
          "title": "Deuxième fichier valide (CSV)",
          "name": "exemple-valide-eco-compteur.csv",
-         "path": "https://raw.githubusercontent.com/etalab/comptage-mobilites-site/v0.1.0/exemple-valide-eco-compteur.csv"
+         "path": "https://raw.githubusercontent.com/etalab/comptage-mobilites-site/v0.2.0/exemple-valide-eco-compteur.csv"
       }
    ],
    "created": "2021-05-06",
-   "lastModified": "2021-11-25",
-   "version": "0.1.0",
+   "lastModified": "2022-10-27",
+   "version": "0.2.0",
    "contributors": [
       {
          "title": "Miryad Ali",
@@ -80,6 +80,15 @@
          "type": "string",
          "constraints": {
             "required": false
+         }
+      },
+      {
+         "name": "name",
+         "description": "Nom du site",
+         "example": "Baix",
+         "type": "string",
+         "constraints": {
+            "required": true
          }
       },
       {

--- a/schema.json
+++ b/schema.json
@@ -83,7 +83,7 @@
          }
       },
       {
-         "name": "name",
+         "name": "site_name",
          "description": "Nom du site",
          "example": "Baix",
          "type": "string",


### PR DESCRIPTION
Ajout champ "site_name" suite à une remarque d'Eco_compteur Le champ apparaissait dans la dernière version du brouillon du schéma mais nous avons oublié de le mettre quand on a publié le schéma.

Cette PR fait référence à cette issue de Vincent d'Eco-compteur : https://github.com/etalab/schema-comptage-mobilites-site/issues/22

⚠️​ Attendre retour de Thibaut pour merger la PR 


Vous publiez une nouvelle version d'un schéma ?
Pensez à réaliser les actions suivantes.

- [x] Mettre à jour les fichiers d'exemples
- [x] Mettre à jour le champ `version`
- [x] Mettre à jour le champ `lastModified`
- [x] Changer les liens vers les fichiers d'exemples présents dans `schema.json` et `README.md`
- [x] Mettre à jour le fichier `CHANGELOG.md` en incluant une description de la version
- [ ] Merger cette pull-request
- [ ] Publier un nouveau tag et une nouvelle version
- [ ] Prévenir les utilisateurs de ce schéma